### PR TITLE
Package installers fixed.

### DIFF
--- a/commands/system/packages/installpackage-autodl
+++ b/commands/system/packages/installpackage-autodl
@@ -8,13 +8,13 @@
 #
 # QuickBox Copyright (C) 2016 Swizards.net
 # Licensed under GNU General Public License v3.0 GPL-3 (in short)
-# 
+#
 #   You may copy, distribute and modify the software as long as you track
-#   changes/dates in source files. Any modifications to our software 
-#   including (via compiler) GPL-licensed code must also be made available 
+#   changes/dates in source files. Any modifications to our software
+#   including (via compiler) GPL-licensed code must also be made available
 #   under the GPL along with build & install instructions.
 #
-MASTER=$(cat /root/master.txt)
+MASTER=$(cat /etc/apache2/master.txt)
 IRSSIIP=$(curl -s http://ipecho.net/plain || curl -s http://ifconfig.me/ip ; echo)
 IRSSI_PASS=$(_string)
 IRSSI_PORT=$(shuf -i 2000-61000 -n 1)

--- a/commands/system/packages/installpackage-btsync
+++ b/commands/system/packages/installpackage-btsync
@@ -15,7 +15,7 @@
 #   under the GPL along with build & install instructions.
 #
 REPOURL="https://github.com/Swizards/QuickBox/raw/master/sources/"
-MASTER=$(cat /root/master.txt)
+MASTER=$(cat /etc/apache2/master.txt)
 BTSYNCIP=$(curl -s http://ipecho.net/plain || curl -s http://ifconfig.me/ip ; echo)
 OUTTO="/root/quick-box.log"
 

--- a/commands/system/packages/removepackage-btsync
+++ b/commands/system/packages/removepackage-btsync
@@ -14,7 +14,7 @@
 #   including (via compiler) GPL-licensed code must also be made available
 #   under the GPL along with build & install instructions.
 #
-MASTER=$(cat /root/master.txt)
+MASTER=$(cat /etc/apache2/master.txt)
 
 function _removeBTSync() {
   sudo killall btsync


### PR DESCRIPTION
As per issue #49 - regarding installer/removal issues with BTSync

**Credits** 
Thank you @oOMrYairOo for pointing this out, otherwise it would had just been another day at the office.

**Info** 
installers were trying to read the master.txt (script owner name file) file from the /root/ directory. This directory -for script security reasons- has now been placed within /etc/apache2/