### PR TITLE
Reliably kill rtorrent et al for reloading

### DIFF
--- a/commands/reload
+++ b/commands/reload
@@ -8,7 +8,7 @@
 #
 OUTTO=/dev/null
 export USER=`id -un`
-killall -u $USER irssi >>"${OUTTO}" 2>&1
-killall -u $USER rtorrent >>"${OUTTO}" 2>&1
+pkill -u $USER irssi >>"${OUTTO}" 2>&1
+pkill -u $USER rtorrent >>"${OUTTO}" 2>&1
 killall -U $USER main >>"${OUTTO}" 2>&1
 rm -rf ~/.sessions/rtorrent.lock

--- a/sources/sudoers
+++ b/sources/sudoers
@@ -18,7 +18,7 @@ Defaults	secure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/b
 Cmnd_Alias   CLEANMEM = /usr/local/bin/clean_mem, /proc/sys/vm/drop_caches
 Cmnd_Alias   PACKAGEHANDLE = /usr/local/bin/installpackage-*, /usr/local/bin/removepackage-*
 Cmnd_Alias   PLUGINHANDLE = /usr/local/bin/installplugin-*, /usr/local/bin/removeplugin-*
-Cmnd_Alias   GENERALCMNDS = /usr/bin/ifstat, /usr/bin/vnstat, /usr/sbin/repquota, /bin/grep, /usr/bin/awk, /usr/bin/reload, /etc/init.d/apache2 restart
+Cmnd_Alias   GENERALCMNDS = /usr/bin/ifstat, /usr/bin/vnstat, /usr/sbin/repquota, /bin/grep, /usr/bin/awk, /usr/bin/reload, /etc/init.d/apache2 restart, /usr/bin/pkill, /usr/bin/killall
 
 # User privilege specification
 root	ALL=(ALL:ALL) ALL


### PR DESCRIPTION
When using the command:

killall -u ${user} rtorrent

The shell spits back an error that no processes matching rtorrent could be found. By using pkill instead of killall we can reliably kill rtorrent so that it can be brought back online with the startup script.


Also sudoers file is missing the proper permissions to use sudo with pkill/killall -- the addition to sudoers allows www-data to have the permissions it needs.

Finally, it appears sudoers is not actually being set on Ubuntu 16.04 the main script needs to be fixed but I am uncertain where the problem actually lies.